### PR TITLE
Add/hmong antibiotics translations

### DIFF
--- a/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Ceftriaxone.java
+++ b/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Ceftriaxone.java
@@ -8,7 +8,6 @@ import android.support.v7.app.AppCompatActivity;
  */
 
 public class Hmong_Antibiotic_Ceftriaxone extends AppCompatActivity {
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Ceftriaxone.java
+++ b/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Ceftriaxone.java
@@ -8,9 +8,11 @@ import android.support.v7.app.AppCompatActivity;
  */
 
 public class Hmong_Antibiotic_Ceftriaxone extends AppCompatActivity {
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.hmong_antibiotic_ceftriaxone);
+        AudioPlayer.CreateAudioPlayer(this, R.raw.hmong_ceftriaxone);
     }
 }

--- a/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Cephalexin.java
+++ b/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Cephalexin.java
@@ -1,4 +1,5 @@
 package healthyhostapp.healthyhost;
+
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -13,6 +14,6 @@ public class Hmong_Antibiotic_Cephalexin extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.hmong_antibiotic_cephalexin);
+        AudioPlayer.CreateAudioPlayer(this, R.raw.hmong_cephalexcin);
     }
 }
-

--- a/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Doxycycline.java
+++ b/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Doxycycline.java
@@ -6,10 +6,12 @@ import android.support.v7.app.AppCompatActivity;
 /**
  * Created by herda on 11/16/2017.
  */
+
 public class Hmong_Antibiotic_Doxycycline extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.hmong_antibiotic_doxycycline);
+        AudioPlayer.CreateAudioPlayer(this, R.raw.hmong_doxycycline);
     }
 }

--- a/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Erythromycin.java
+++ b/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Erythromycin.java
@@ -1,4 +1,5 @@
 package healthyhostapp.healthyhost;
+
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -13,5 +14,6 @@ public class Hmong_Antibiotic_Erythromycin extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.hmong_antibiotic_erythromycin);
+        AudioPlayer.CreateAudioPlayer(this, R.raw.hmong_erythromycin);
     }
 }

--- a/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Flucloxacillin.java
+++ b/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Flucloxacillin.java
@@ -12,5 +12,6 @@ public class Hmong_Antibiotic_Flucloxacillin extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.hmong_antibiotic_flucloxacillin);
+        AudioPlayer.CreateAudioPlayer(this, R.raw.hmong_flucloxacillin);
     }
 }

--- a/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Levaquin.java
+++ b/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Levaquin.java
@@ -12,5 +12,6 @@ public class Hmong_Antibiotic_Levaquin extends AppCompatActivity{
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.hmong_antibiotic_levaquin);
+        AudioPlayer.CreateAudioPlayer(this, R.raw.hmong_levaquin);
     }
 }

--- a/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Metronidazole.java
+++ b/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Metronidazole.java
@@ -12,5 +12,6 @@ public class Hmong_Antibiotic_Metronidazole extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.hmong_antibiotic_metronidazole);
+        AudioPlayer.CreateAudioPlayer(this, R.raw.hmong_metronidazole);
     }
 }

--- a/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Ofloxacin.java
+++ b/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Ofloxacin.java
@@ -12,5 +12,6 @@ public class Hmong_Antibiotic_Ofloxacin extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.hmong_antibiotic_ofloxacin);
+        AudioPlayer.CreateAudioPlayer(this, R.raw.hmong_ofloxacin);
     }
 }

--- a/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Penecillin_G.java
+++ b/app/src/main/java/healthyhostapp/healthyhost/Hmong_Antibiotic_Penecillin_G.java
@@ -12,5 +12,6 @@ public class Hmong_Antibiotic_Penecillin_G extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.hmong_antibiotic_penecillin_g);
+        AudioPlayer.CreateAudioPlayer(this, R.raw.moonlight);
     }
 }

--- a/app/src/main/res/layout/hmong_antibiotic_ceftriaxone.xml
+++ b/app/src/main/res/layout/hmong_antibiotic_ceftriaxone.xml
@@ -14,6 +14,12 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
+            <fragment android:name="healthyhostapp.healthyhost.AudioPlayer"
+                android:id="@+id/audioPlayer"
+                android:layout_weight="1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/hmong_antibiotic_cephalexin.xml
+++ b/app/src/main/res/layout/hmong_antibiotic_cephalexin.xml
@@ -14,6 +14,12 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
+            <fragment android:name="healthyhostapp.healthyhost.AudioPlayer"
+                android:id="@+id/audioPlayer"
+                android:layout_weight="1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/hmong_antibiotic_doxycycline.xml
+++ b/app/src/main/res/layout/hmong_antibiotic_doxycycline.xml
@@ -14,6 +14,12 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
+            <fragment android:name="healthyhostapp.healthyhost.AudioPlayer"
+                android:id="@+id/audioPlayer"
+                android:layout_weight="1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/hmong_antibiotic_erythromycin.xml
+++ b/app/src/main/res/layout/hmong_antibiotic_erythromycin.xml
@@ -14,6 +14,12 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
+            <fragment android:name="healthyhostapp.healthyhost.AudioPlayer"
+                android:id="@+id/audioPlayer"
+                android:layout_weight="1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/hmong_antibiotic_flucloxacillin.xml
+++ b/app/src/main/res/layout/hmong_antibiotic_flucloxacillin.xml
@@ -14,6 +14,12 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
+            <fragment android:name="healthyhostapp.healthyhost.AudioPlayer"
+                android:id="@+id/audioPlayer"
+                android:layout_weight="1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/hmong_antibiotic_levaquin.xml
+++ b/app/src/main/res/layout/hmong_antibiotic_levaquin.xml
@@ -3,7 +3,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent">
-
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -15,6 +14,12 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
+            <fragment android:name="healthyhostapp.healthyhost.AudioPlayer"
+                android:id="@+id/audioPlayer"
+                android:layout_weight="1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -25,7 +30,8 @@
                 android:textAlignment="center"
                 android:textColor="#000000"
                 android:textSize="40dp"
-                android:textStyle="bold" /> <!--This is where the name of the page goes-->
+                android:textStyle="bold"
+                /> <!--This is where the name of the page goes-->
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/hmong_antibiotic_metronidazole.xml
+++ b/app/src/main/res/layout/hmong_antibiotic_metronidazole.xml
@@ -14,6 +14,12 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
+            <fragment android:name="healthyhostapp.healthyhost.AudioPlayer"
+                android:id="@+id/audioPlayer"
+                android:layout_weight="1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/hmong_antibiotic_ofloxacin.xml
+++ b/app/src/main/res/layout/hmong_antibiotic_ofloxacin.xml
@@ -14,6 +14,12 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
+            <fragment android:name="healthyhostapp.healthyhost.AudioPlayer"
+                android:id="@+id/audioPlayer"
+                android:layout_weight="1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/hmong_antibiotic_penecillin_g.xml
+++ b/app/src/main/res/layout/hmong_antibiotic_penecillin_g.xml
@@ -14,6 +14,12 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
+            <fragment android:name="healthyhostapp.healthyhost.AudioPlayer"
+                android:id="@+id/audioPlayer"
+                android:layout_weight="1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"


### PR DESCRIPTION
today I further implemented the knowledge I have gained in regards to java coding. I am not a cse major, so this all seems pretty exciting. 
on 02/27/2018 I was given the task to add the audio player to all **Hmong antibiotics.** 

I used the following as resources: 
hmong_antibiotic_amoxicillin (reference)
hmong_antibiotic_azythromycin (reference)

I completed the following based off of the references above:
hmong_antibiotic_cefriaxone (done)
hmong_antibiotic_cephalexin (done)
hmong_antibiotic_doxycycline(done)
hmong_antibiotic_erythromycon (done)
hmong_antibiotic_flucloxacillin (done)
hmong_antibiotic_levaquin (done)
hmong_antibiotic_metronidazole (done)
hmong_antibiotic_ofloxacin (done)
hmong_antibiotic_penecillin_6 (no audio file was found, moonlight was used in place)

In addition, I found the following in android studio, but I did not find the pages within the healthy host application:
hmong_antibiotic_improper
hmong_antibiotic_proper
hmong_antibiotic_usage
hmong_antibiotic

Best,
patrick coldivar